### PR TITLE
応用実装：インクリメンタルサーチのユーザー表示

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -30,11 +30,16 @@ $(function() {
       $(`#${userId}`).append(html);
   }
   $("#user-search-field").on("keyup", function() {
+    let index = $('.user-search-remove').length;
+    let user_id = [];
+    for(let i=0; i<index; i++){
+      user_id.push($('.user-search-remove').eq(i).data('user-id'));
+    };
     let input = $("#user-search-field").val();
     $.ajax({
       type: "GET",
       url: "/users",
-      data: { keyword: input },
+      data: { keyword: input, user_id: user_id },
       dataType: "json"
     })
     .done(function(users) {
@@ -55,7 +60,6 @@ $(function() {
     });
   });
   $(document).on("click", ".chat-group-user__btn--add", function() {
-    console.log
     const userName = $(this).attr("data-user-name");
     const userId = $(this).attr("data-user-id");
     $(this)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@ class UsersController < ApplicationController
   
   def index
     return nil if params[:keyword] == ""
-    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).where.not(id: params[:user_id]).limit(10)
+
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -7,9 +7,11 @@
           %li= message
   .chat-group-form__field
     .chat-group-form__field--left
-      = f.label :name, class: 'chat-group-form__label'
+      = f.label :name, "グループ名", class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+      -# 文字を入力する検索欄にてhidden_fieldを使用しgroup.idを送るようにする
+      = f.hidden_field :id, class: "chat__group_id", value: group.id
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
     .chat-group-form__field--left
@@ -19,24 +21,24 @@
         %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
         #user-search-result
 
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
 
-        #chat-group-users.js-add-user
-          .chat-group-user.clearfix.js-chat-member
-            %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
-            %p.chat-group-user__name= current_user.name
+      #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
 
-          - group.users.each do |user|
-            - if current_user.name != user.name
-              .chat-group-user.clearfix.js-chat-member
-                %input{name: "group[user_ids][]", type: "hidden", value: user.id}
-                %p.chat-group-user__name
-                  = user.name
-                %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
-                  削除
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn{ data: {user: {id: user.id}}}
+                削除
             
     / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
     -# = f.collection_check_boxes :user_ids, User.all, :id, :name


### PR DESCRIPTION
#What
1. 追加したユーザーがインクリメンタルサーチの結果に出てこないようにする
2. 削除したユーザーがインクリメンタルサーチの結果に出てくるようにする

#Why
チャットメンバーを表示する際、
・「追加」したにもかかわらず、
　再度チャットメンバーを検索すると「追加したメンバー」が再表示されてしまう。
　これでは、誰を追加したのか不明瞭だったため、改善。
・また、「メンバーから削除」したにもかかわらず、
　同ページ上でメンバー検索に再表示されなかったため、
　誤って削除した場合の再登録が面倒だった。
　それを「削除ボタン」を押したら検索結果に再表示させることで
　改善することが目的である。
　
![reinas_ChatSpace_apply](https://user-images.githubusercontent.com/61730977/77140304-8c644980-6abc-11ea-806b-15d723184bda.gif)
